### PR TITLE
Add `initOnly` option and ability to manually load scripts

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -13,6 +13,7 @@ class App {
     this.commands = [
       { handler: this.queues, method: 'register', as: 'register' },
       { handler: this.queues, method: 'call', as: 'call' },
+      { handler: this.queues, method: 'load', as: 'load' },
     ].reduce((o, binding) => {
       const { handler, method } = binding;
       return { ...o, [binding.as]: handler[method].bind(handler) };

--- a/src/app/queues.js
+++ b/src/app/queues.js
@@ -17,6 +17,7 @@ class Queues {
     attrs,
     onScriptBuild,
     onScriptLoad,
+    initOnly,
   } = {}) {
     if (!name) throw new Error('A queue name is required.');
     if (this.queues[name]) throw new Error(`A script queue as already been registered for '${name}'`);
@@ -31,6 +32,7 @@ class Queues {
       queryString: this.queryString,
       onScriptBuild,
       onScriptLoad,
+      initOnly,
     });
   }
 
@@ -39,6 +41,12 @@ class Queues {
     if (!queue) throw new Error(`No queue has been registered for '${name}'`);
     queue.push({ fn });
     return this;
+  }
+
+  load({ name } = {}) {
+    const queue = this.queues[name];
+    if (!queue) throw new Error(`No queue has been registered for '${name}'`);
+    return queue.loadAndCallFns(true);
   }
 }
 

--- a/src/index.hbs
+++ b/src/index.hbs
@@ -70,11 +70,18 @@
           googletag.cmd.push(function() { googletag.enableServices(); });
         },
         /**
+         * When true, will only call the init function above but will _not_ load the remote script.
+         * To call the remote script, the `deferScript('load', { name: '' })` call must be executed.
+         * This is useful when you want to manually control when the script should execute (e.g. on scroll or intersection)
+         */
+        /**
          * Script attributes to pass.
          * By default both async and defer are set.
          */
          attrs: { async: 1, defer: 1 },
       });
+      // manually calling the googletag script.
+      deferScript('load', { name: 'googletag' });
 
       deferScript('register', {
         name: 'lazysizes',

--- a/src/index.hbs
+++ b/src/index.hbs
@@ -74,6 +74,7 @@
          * To call the remote script, the `deferScript('load', { name: '' })` call must be executed.
          * This is useful when you want to manually control when the script should execute (e.g. on scroll or intersection)
          */
+         initOnly: true,
         /**
          * Script attributes to pass.
          * By default both async and defer are set.


### PR DESCRIPTION
When `initOnly` is true, the registered script will only call the init function but will _not_ load the remote script.

To call the remote script, `deferScript('load', { name: 'someRegisteredName' })` must be executed.

This is useful if you want manual control over when the remote script is loaded (e.g. on scroll or intersection)